### PR TITLE
Fix dependabot merge #8279

### DIFF
--- a/templates/.github/workflows/dependabot-auto-merge.yaml
+++ b/templates/.github/workflows/dependabot-auto-merge.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The --auto flag, according to the docs, merges a PR automatically when
the PR passes branch protection rules, or has requirements checks
enabled.

Example error message from some repositories:

```
GraphQL: Pull request Protected branch rules not configured for this
branch (enablePullRequestAutoMerge)
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] feat: non-breaking change which adds new functionality
- [ ] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

Please indicate if your PR introduces a breaking change
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
