### PR TITLE
fix: packagist token required for PHP apps #0000

### DIFF
--- a/repo.schema.yaml
+++ b/repo.schema.yaml
@@ -35,7 +35,6 @@ properties:
       - application
       - library
       - symfony-bundle
-      - application-nodejs
 
   codeowners:
     type: array
@@ -206,7 +205,9 @@ properties:
       private_packagist:
         type: boolean
         default: true
-        description: Repository requires private packagist access (default true)
+        description: >
+          Repository requires private packagist access (default true). Property is ignored is not of type php-*, or the
+          other (deprecated) types: application, library, symfony-bundle.
       postCreateCommand:
         description: Additional shell commands to run during the postCreate lifecycle event
         type: string

--- a/templates/.devcontainer/devcontainer.json.j2
+++ b/templates/.devcontainer/devcontainer.json.j2
@@ -41,7 +41,7 @@
   "remoteUser": "vscode",
 
   "secrets": {
-{% if repo.devcontainer.private_packagist %}
+{% if repo.devcontainer.private_packagist and (repo.type in ['application', 'library', 'symfony-bundle'] or repo.type.startswith('php-')) %}
     "PACKAGIST_TOKEN": {
       "description": "Packagist access token, required for installation of composer packages from private packagist",
       "documentationUrl": "https://packagist.com/orgs/linkorb"

--- a/templates/.devcontainer/postCreate.sh.j2
+++ b/templates/.devcontainer/postCreate.sh.j2
@@ -10,11 +10,11 @@ git config commit.template .devcontainer/git/linkorb_commit.template
 cp .devcontainer/git/hooks/pre-push .git/hooks/pre-push
 chmod +x .git/hooks/pre-push
 
+{% if repo.type in ['application', 'library', 'symfony-bundle'] or repo.type.startswith('php-') %}
 {% if repo.devcontainer.private_packagist %}
 composer config --global --auth http-basic.repo.packagist.com "$GITHUB_USER" "$PACKAGIST_TOKEN"
 {% endif %}
 
-{% if repo.type in ['application', 'library', 'symfony-bundle'] or repo.type.startswith('php-') %}
 composer install
 {% endif %}
 


### PR DESCRIPTION
Change the devcontainer generation criteria to only conditionally inject the packagist token requirement, which depends on the repo.devcontainer.private_packagist token only when the project is also a PHP type project.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] feat: non-breaking change which adds new functionality
- [x] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

Please indicate if your PR introduces a breaking change
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)