### PR TITLE
fix: release workflow for default branch #000

### DIFF
--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -108,7 +108,7 @@ jobs:
         branches: |
           [
             '+([0-9])?(.{+([0-9]),x}).x',
-            'main',
+            '[[ repo.github.default_branch ]]',
             'next',
             'next-major',
             {


### PR DESCRIPTION
Workflow used to default to the main branch, however not all the repositories have converted to the main branch, and some still use the master branch.

## Types of changes

- [x] fix: non-breaking change which fixes a bug or an issue
- [x] ci: changes to continuous integration or continuous delivery scripts or configuration files


## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
