### PR TITLE
fix: do not overwrite package json during release

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v2
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'

--- a/tasks/other-dev-generated-files.yaml
+++ b/tasks/other-dev-generated-files.yaml
@@ -1,17 +1,23 @@
-- name: copy github actions workflow files
-  ansible.builtin.template:
-    src: "./templates/.github/workflows/{{ item }}.j2"
-    dest: "{{ repo_path + '/.github/workflows/' + item }}"
-    variable_start_string: '[['
-    variable_end_string: ']]'
-  loop:
-    - 00-start.yaml
-    - 10-review.yaml
-    - 30-release-and-build.yaml
-    - 40-helm.yaml
-    - 50-security.yaml
-    - 90-cleanup.yaml
-  when: repo.github.features.sdlc_workflows
+- when: repo.github.features.sdlc_workflows
+  block:
+  - name: copy semantic-release .releaserc file
+    ansible.builtin.copy:
+      src: "./templates/.releaserc"
+      dest: "{{ repo_path }}/.releaserc"
+
+  - name: copy github actions workflow files
+    ansible.builtin.template:
+      src: "./templates/.github/workflows/{{ item }}.j2"
+      dest: "{{ repo_path + '/.github/workflows/' + item }}"
+      variable_start_string: '[['
+      variable_end_string: ']]'
+    loop:
+      - 00-start.yaml
+      - 10-review.yaml
+      - 30-release-and-build.yaml
+      - 40-helm.yaml
+      - 50-security.yaml
+      - 90-cleanup.yaml
 
 - name: generate .dockerignore
   ansible.builtin.template:

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -54,12 +54,6 @@ jobs:
                 "@semantic-release/commit-analyzer",
                 "@semantic-release/github",
                 "@semantic-release/release-notes-generator",
-                [
-                  "@semantic-release/npm",
-                      {
-                        "npmPublish": false
-                      }
-                ],
                 "@semantic-release/changelog",
                 [
                     "@semantic-release/git",

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -44,31 +44,6 @@ jobs:
     - name: write semantic-release config
       uses: DamianReeves/write-file-action@v1.3 # XXX does not support short version format
       with:
-        path: package.json
-        contents: |
-          {
-            "name": "linkorb-releases",
-            "version": "1.0.0",
-            "description": "Dependencies for the LinkORB release workflow",
-            "main": "index.js",
-            "scripts": {
-              "test": "echo \"Error: no test specified\" && exit 1"
-            },
-            "author": "",
-            "license": "ISC",
-            "devDependencies": {
-              "@codedependant/semantic-release-docker": "^4.1.0",
-              "@semantic-release-plus/docker": "^3.1.2",
-              "@semantic-release/changelog": "^6.0.1",
-              "@semantic-release/exec": "^6.0.3",
-              "@semantic-release/git": "^10.0.1"
-            }
-          }
-        write-mode: overwrite
-
-    - name: write semantic-release config
-      uses: DamianReeves/write-file-action@v1.3 # XXX does not support short version format
-      with:
         path: .releaserc
         contents: |
           {
@@ -122,10 +97,10 @@ jobs:
           ]
         additional-packages: |
           ['@semantic-release/changelog', '@semantic-release/git']
+        repository-url: 'git+https://github.com/linkorb/${{ env.CI_REPOSITORY_NAME }}.git'
         tag-format: 'v${version}'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
 
     - name: Docker meta
       id: meta

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -49,7 +49,7 @@ jobs:
           {
             "branches": ["master", "main" ],
             "debug": "True",
-            "repositoryUrl": 'git+https://github.com/linkorb/${{ env.CI_REPOSITORY_NAME }}.git',
+            "repositoryUrl": "git+https://github.com/${{ github.repository_owner }}/${{ env.CI_REPOSITORY_NAME }}.git",
             "plugins": [
                 "@semantic-release/commit-analyzer",
                 "@semantic-release/github",
@@ -97,7 +97,7 @@ jobs:
           ]
         additional-packages: |
           ['@semantic-release/changelog', '@semantic-release/git']
-        repository-url: 'git+https://github.com/linkorb/${{ env.CI_REPOSITORY_NAME }}.git'
+        repository-url: 'https://github.com/${{ github.repository_owner }}/${{ env.CI_REPOSITORY_NAME }}.git'
         tag-format: 'v${version}'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,7 +107,7 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: |
-          ghcr.io/linkorb/${{ env.CI_REPOSITORY_NAME }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.CI_REPOSITORY_NAME }}
         tags: |
           type=sha
           type=raw,value=latest,enable={{is_default_branch}}

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -41,32 +41,6 @@ jobs:
         # (set provenance=false in docker/build-push-action@v4)
         driver-opts: network=host,image=moby/buildkit:v0.10.5
 
-    - name: write semantic-release config
-      uses: DamianReeves/write-file-action@v1.3 # XXX does not support short version format
-      with:
-        path: .releaserc
-        contents: |
-          {
-            "branches": ["master", "main" ],
-            "debug": "True",
-            "plugins": [
-                "@semantic-release/commit-analyzer",
-                "@semantic-release/github",
-                "@semantic-release/release-notes-generator",
-                "@semantic-release/changelog",
-                [
-                    "@semantic-release/git",
-                    {
-                        "assets": [
-                            "CHANGELOG.md"
-                        ],
-                        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-                    }
-                ]
-             ]
-          }
-        write-mode: overwrite
-
     - name: Create release
       id: semantic-release
       uses: codfish/semantic-release-action@v3

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -49,7 +49,6 @@ jobs:
           {
             "branches": ["master", "main" ],
             "debug": "True",
-            "repositoryUrl": "git+https://github.com/${{ github.repository_owner }}/${{ env.CI_REPOSITORY_NAME }}.git",
             "plugins": [
                 "@semantic-release/commit-analyzer",
                 "@semantic-release/github",

--- a/templates/.releaserc
+++ b/templates/.releaserc
@@ -1,0 +1,19 @@
+{
+  "branches": ["master", "main" ],
+  "debug": "True",
+  "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/github",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      [
+          "@semantic-release/git",
+          {
+              "assets": [
+                  "CHANGELOG.md"
+              ],
+              "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+          }
+      ]
+   ]
+}


### PR DESCRIPTION
## Proposed changes

Make the release workflow easier to test by removing hardcoded organization name, and remove it's reliance on a package.json file. Previously it would overwrite the file, just to install semantic release dependencies, which can be done instead via action parameters.

## Types of changes

- [x] fix: non-breaking change which fixes a bug or an issue
- [x] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [x] chore: general tasks or anything that doesn't fit the other commit types

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc