### PR TITLE
Default release workflow explicit permissions #8907

### DIFF
--- a/templates/.github/workflows/10-review.yaml.j2
+++ b/templates/.github/workflows/10-review.yaml.j2
@@ -4,6 +4,7 @@ name: ReviewCode
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
+  workflow_call:
 
 jobs:
   check-for-cc:

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -15,6 +15,11 @@ on:
     branches:
       - [[ repo.github.default_branch ]]
 
+permissions:
+  contents: write
+  issues: write
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default GITHUB_TOKEN secret doesn't have write permissions by
default for packages. One option is to set the token by default to have
write permission, per repository, or as with this change, mark the
additional permissions requested explicitly per workflow.



## Types of changes

- [x] fix: non-breaking change which fixes a bug or an issue
- [x] ci: changes to continuous integration or continuous delivery scripts or configuration files


## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc