### PR TITLE
feat: .gitrelease file for container build 

### DIFF
--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -68,7 +68,7 @@ jobs:
             }
           ]
         additional-packages: |
-          ['@semantic-release/changelog', '@semantic-release/git']
+          ['@semantic-release/changelog', '@semantic-release/git', '@semantic-release/exec']
         repository-url: 'https://github.com/${{ github.repository_owner }}/${{ env.CI_REPOSITORY_NAME }}.git'
         tag-format: 'v${version}'
       env:

--- a/templates/.releaserc
+++ b/templates/.releaserc
@@ -14,6 +14,12 @@
               ],
               "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
           }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "publishCmd": "echo ${nextRelease.version} > .gitrelease"
+        }
       ]
    ]
 }


### PR DESCRIPTION
Generate a .gitrelease file as the final step of the @semantic-release action. This way the file will be available in the followup docker image build step, but not part of the committed changelog.

## Types of changes

- [x] feat: non-breaking change which adds new functionality
- [x] ci: changes to continuous integration or continuous delivery scripts or configuration files

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
