### PR TITLE
fix: disable composer-unused git push check #8978

### DIFF
--- a/tasks/php-qa.yaml
+++ b/tasks/php-qa.yaml
@@ -3,10 +3,16 @@
     path: "{{ repo_path + '/.github/' }}"
   register: directory_exists
 
-- name: Generate composer-unused.php file
-  ansible.builtin.template:
-    src: "{{ './templates/php-qa/composer-unused.php.j2' }}"
-    dest: "{{ repo_path + '/composer-unused.php' }}"
+- name: Ensure composer-unused.php is absent
+  ansible.builtin.file:
+    path: "{{ repo_path + '/composer-unused.php' }}"
+    state: absent
+
+# XXX: composer-unused as part of Card (epic) 8980
+#- name: Generate composer-unused.php file
+#  ansible.builtin.template:
+#    src: "{{ './templates/php-qa/composer-unused.php.j2' }}"
+#    dest: "{{ repo_path + '/composer-unused.php' }}"
 
 - name: Generate .php-cs-fixer.dist.php file
   ansible.builtin.template:

--- a/templates/.devcontainer/postCreate.sh.j2
+++ b/templates/.devcontainer/postCreate.sh.j2
@@ -8,8 +8,6 @@ sudo rm /usr/lib/python3.*/EXTERNALLY-MANAGED || true
 git config commit.template .devcontainer/git/linkorb_commit.template
 
 {% if repo.type in ['application', 'library', 'symfony-bundle'] or repo.type.startswith('php-') %}
-cp .devcontainer/git/hooks/pre-push .git/hooks/pre-push
-chmod +x .git/hooks/pre-push
 
 {% if repo.devcontainer.private_packagist %}
 composer config --global --auth http-basic.repo.packagist.com "$GITHUB_USER" "$PACKAGIST_TOKEN"

--- a/templates/.devcontainer/postStart.sh.j2
+++ b/templates/.devcontainer/postStart.sh.j2
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 # {{ repo_managed }}
 
+# pre-push composer-unused hook disabled. See Card #8980
+if [ -f .git/hooks/pre-push ]; then
+  diff .devcontainer/git/hooks/pre-push .git/hooks/pre-push
+  if [ $? -eq 0 ]; then
+    rm .git/hooks/pre-push
+  fi
+fi
 {{ repo.devcontainer.postStartCommand|default('') }}


### PR DESCRIPTION
In more recent situations, where the git hook was setup it led to ambiguous errors about paths not being correct, where it used to work before. As to avoid tripping users on this confuration, it has been disabled and tracked separately as part of the 8980 epic (relating to all things PHP QA).


## Types of changes

- [x] fix: non-breaking change which fixes a bug or an issue

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
