### PR TITLE
feat: bundle playbook-cwd as an executable #9005

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -1,0 +1,65 @@
+name: Release bundle
+
+on:
+  push:
+    tags:
+      - '*'
+
+
+jobs:
+  create-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: download ansible-bundler
+        uses: robinraju/release-downloader@v1
+        id: download
+        with:
+          # switch to upstream repository when merged https://github.com/kriansa/ansible-bundler/pull/16
+          repository: 'mhitza/ansible-bundler'
+          fileName: '*_amd64.deb'
+          out-file-path: '/tmp'
+          latest: true
+      - name: install ansible-bundler
+        run: sudo dpkg -i ${{ fromJson(steps.download.outputs.downloaded_files)[0] }}
+
+      - name: package repo-ansible.run
+        run: >
+          bundle-playbook -f playbook-cwd.yaml
+          --extra-deps=tasks --extra-deps=templates --extra-deps=library
+          --extra-deps=repo.schema.yaml
+          --python-package=jsonschema
+          -o repo-ansible.run
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: repo-ansible.run
+          retention-days: 1
+
+  test-bundle:
+    needs: [ create-bundle ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+      - run: python --version
+      - name: quick binary test run on this repo - ${{ matrix.os }}
+        run: chmod +x ./artifact/repo-ansible.run && ./artifact/repo-ansible.run
+        env:
+          ANSIBLE_DISPLAY_OK_HOSTS: 0
+          ANSIBLE_DISPLAY_SKIPPED_HOSTS: 0
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [ test-bundle ]
+    steps:
+      - uses: actions/download-artifact@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: artifact/repo-ansible.run
+          generate_release_notes: true
+          make_latest: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 workspace/
 generated-inventory.ini
+repo-ansible.run


### PR DESCRIPTION
The purpose of this bundling is to simplify the way other users use the repo-ansible project, without needing to go through the manual cloning of this repository, ansible and its dependencies installation.

For bulk operations and development, users are still expected to clone the repository and have ansible already installed locally.

## Types of changes


- [x] feat: non-breaking change which adds new functionality
## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)