### PR TITLE
fix: handlind of directories with spaces

### DIFF
--- a/tasks/retrieve-validate-repo-data.yaml
+++ b/tasks/retrieve-validate-repo-data.yaml
@@ -1,5 +1,5 @@
 - name: merge repo.yaml data with defaults
-  ansible.builtin.command: "./library/repo_data.py {{ repo_path }}/repo.yaml"
+  ansible.builtin.command: "./library/repo_data.py '{{ repo_path }}/repo.yaml'"
   register: repo_data
   changed_when: false
 


### PR DESCRIPTION
Issue crops up when the external python command is invoked, whereas for all other cases where paths are handled by Ansible modules this should not cause an issue.

## Types of changes

- [x] fix: non-breaking change which fixes a bug or an issue

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
