### PR TITLE
fix: devcontainer + Windows + git config #9067

### DIFF
--- a/templates/.devcontainer/postCreate.sh.j2
+++ b/templates/.devcontainer/postCreate.sh.j2
@@ -5,6 +5,10 @@
 # or removal of a certain file.
 sudo rm /usr/lib/python3.*/EXTERNALLY-MANAGED || true
 
+# This is a workaround on an issue with the devcontainer reported on Windows where followup git config commands would
+# fail. #9067
+git config --add safe.directory /app
+
 git config commit.template .devcontainer/git/linkorb_commit.template
 
 {% if repo.type in ['application', 'library', 'symfony-bundle'] or repo.type.startswith('php-') %}


### PR DESCRIPTION
Reported fix for an issue that shows up on Windows when running devcontainers in VSCode and the git config command is failing due to different users between the host and the git directory within the container

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] fix: non-breaking change which fixes a bug or an issue

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
