### PR TITLE
fix: expected location of compose file #9202

### DIFF
--- a/repo.schema.yaml
+++ b/repo.schema.yaml
@@ -206,8 +206,8 @@ properties:
         type: boolean
         default: false
         description: >
-          When enabled no pre-defined .devcontainer/docker-compose.yaml file will be generated, and instead the
-          devcontainer will attempt to use a docker-compose.yaml file located in the root of the repository.
+          When enabled the compose file located at .devcontainer/docker-compose.yaml will no longer get automatically
+          updated. Allowing users to customize their docker-compose setup.
       postCreateCommand:
         description: >
           Additional (shell) commands to run when the containers is created. For a typical project you would specify

--- a/templates/.devcontainer/devcontainer.json.j2
+++ b/templates/.devcontainer/devcontainer.json.j2
@@ -1,10 +1,6 @@
 // {{ repo_managed }}
 {
-{% if repo.devcontainer.custom_docker_compose_yaml %}
-  "dockerComposeFile": "../docker-compose.yaml",
-{% else %}
   "dockerComposeFile": "docker-compose.yml",
-{% endif %}
   "service": "app",
   "workspaceFolder": "/app",
 


### PR DESCRIPTION
In order to avoid ambiguity around the purpose of the docker-compose files within repositories, those that are tailored for devcontainers should reside within the .devcontainer directory.


## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] feat: non-breaking change which adds new functionality
- [x] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

<!-- Please indicate if your PR introduces a breaking change -->
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
