### PR TITLE
fix: disable PR checks reports by reviewdog #9082

### DIFF
--- a/docker/reviewdog/entrypoint.sh
+++ b/docker/reviewdog/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# TODO add in at a later time
+# TODO add this feature at a later time, to make it convenient to quickly fix reported coding style errors
 #fix          - automatically fix coding style when possible (WILL ATTEMPT TO FIX ALL FILES, NOT ONLY THOSE CHANGED)
 
 help=$(cat <<'EOQ'
@@ -25,7 +25,7 @@ for arg in "$@"; do
       reviewdog_args=()
     elif [ "$arg" = "pull-request" ]; then
       reviewdog_args=("-diff=git diff FETCH_HEAD")
-      reviewdog_args+=("-reporter=github-pr-check")
+      reviewdog_args+=("-reporter=local")
     else
       reviewdog_args+=("$arg")
     fi


### PR DESCRIPTION
There are permission issues related to the GitHub API calls that reviewdog is supposed to make, preventing the quality checks from being reported on the PR.

Disabled part of this commit and individually tracked in #9234


## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] feat: non-breaking change which adds new functionality
- [x] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [x] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

<!-- Please indicate if your PR introduces a breaking change -->
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
