### PR TITLE
feat: extend repository description length #0000

### DIFF
--- a/repo.schema.yaml
+++ b/repo.schema.yaml
@@ -24,7 +24,7 @@ properties:
       Repository description that shows up in the sidebar on GitHub, and as the first line of the README after the
       repository name.
     minLength: 1
-    maxLength: 100
+    maxLength: 350
 
   type:
     type: string


### PR DESCRIPTION
The GitHub interface allows up to 350 characters for the repository description. Making repo-ansible conform to those restrictions instead of the initial 100 characters length.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

If this relates to a card, please include a link to the card here. Additionally, please terminate the PR title with `#` and the card number, such as `Fix doomsday bug #1234` -->

<!-- Please indicate if your PR introduces a breaking change -->
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
