### PR TITLE
GitHub Actions workflow to automatically apply PR labels #9650

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -22,6 +22,13 @@ Reads from and writes to the repo.
 Set the step's `env.GITHUB_TOKEN` to `secrets.GITHUB_TOKEN` as in the
 [action's doc][semantic-release-action-doc]
 
+### PR Labeler
+
+Inspects the commits in a pull-request, and applies a series of labels based on conventional-commits nouns.
+
+The tokens are defined in the `.github/settings.yml` file, with the repo-ansible
+template located at `templates/.github/settings.yml.j2`.
+
 ### Login to Container Registry ghcr.io (docker/login-action)
 
 Logs in to ghcr, ready for subsequent actions to push and pull container

--- a/templates/.github/settings.yml.j2
+++ b/templates/.github/settings.yml.j2
@@ -66,19 +66,53 @@ repository:
 
 # Labels: define labels for Issues and Pull Requests
 labels:
-  - name: fix
-    color: CC0000
-    description: An issue with the system.
-
   - name: feat
-    # If including a `#`, make sure to wrap it with quotes!
-    color: '#336699'
-    description: New feature.
+    description: non-breaking change which adds new functionality
+    color: "1D76DB"  # Blue for features (enhancements)
+
+  - name: fix
+    description: non-breaking change which fixes a bug or an issue
+    color: "D73A4A"  # Red for fixes (issues, bugs)
+
+  - name: chore(deps)
+    description: changes to dependencies
+    color: "C2E0C6"  # Light green for dependency updates
+
+  - name: test
+    description: adds or modifies a test
+    color: "E99695"  # Light red/pink for test updates
+
+  - name: docs
+    description: creates or updates documentation
+    color: "0075CA"  # Bright blue for documentation changes
+
+  - name: style
+    description: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
+    color: "6E5494"  # Purple for styling (formatting)
+
+  - name: perf
+    description: code change that improves performance
+    color: "FFC107"  # Yellow for performance improvements
+
+  - name: revert
+    description: reverts a commit
+    color: "000000"  # Black for revert actions
+
+  - name: refactor
+    description: code change that neither fix a bug nor add a new feature
+    color: "F9D0C4"  # Peach/light red for refactoring
+
+  - name: ci
+    description: changes to continuous integration or continuous delivery scripts or configuration files
+    color: "A2EEEF"  # Light blue for CI/CD updates
 
   - name: chore
-    color: CC0000
-    description: A repository chore.
+    description: general tasks or anything that doesn't fit the other commit types
+    color: "BFDADC"  # Muted teal for general chores
 
+  - name: "BREAKING CHANGE"
+    description: fix or feature that would cause existing functionality to not work as expected
+    color: "FF0000"  # Bright red for breaking changes (critical)
 
 # Milestones: define milestones for Issues and Pull Requests
 {#

--- a/templates/.github/workflows/pr-labeler.yaml.j2
+++ b/templates/.github/workflows/pr-labeler.yaml.j2
@@ -1,0 +1,116 @@
+# [[ repo_managed ]]
+name: PR Labeler
+
+permissions:
+  contents: read
+  pull-requests: write  # Allow writing labels on PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR Commits
+        id: get-commits
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const prBody = context.payload.pull_request.body || "";
+            const breakingChangeLabel = "BREAKING CHANGE";
+
+            // Fetch all commits from the PR
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner,
+              repo,
+              pull_number: prNumber
+            });
+
+            // Define Conventional Commit prefixes and corresponding labels
+            const labelMap = {
+              "feat": "feat",
+              "fix": "fix",
+              "chore": "chore",
+              "test": "test",
+              "docs": "docs",
+              "style": "style",
+              "perf": "perf",
+              "revert": "revert",
+              "refactor": "refactor",
+              "ci": "ci",
+              "chore": "chore",
+            };
+
+            // Get current labels on the PR
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: prNumber
+            });
+
+            const existingLabels = new Set(currentLabels.map(label => label.name));
+            const labelsToAdd = new Set();
+            const labelsToRemove = new Set(existingLabels);
+
+            // Inspect commit messages
+            commits.forEach(commit => {
+              const commitMessage = commit.commit.message;
+              for (const [prefix, label] of Object.entries(labelMap)) {
+                if (commitMessage.startsWith(prefix)) {
+                  labelsToAdd.add(label);
+                  labelsToRemove.delete(label);
+                }
+              }
+            });
+
+            // Apply label updates
+            if (labelsToAdd.size > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: Array.from(labelsToAdd)
+              });
+            }
+
+            for (const label of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: label
+              }).catch(error => {
+                if (error.status !== 404) throw error;
+              });
+            }
+
+            const { data: updatedCurrentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: prNumber
+            });
+
+            // Handle "BREAKING CHANGE" label
+            const hasBreakingChangeLabel = updatedCurrentLabels.some(label => label.name === breakingChangeLabel);
+
+            if (prBody.includes("[x] Breaking change") && !hasBreakingChangeLabel) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [breakingChangeLabel]
+              });
+            } else if (!prBody.includes("[x] Breaking change") && hasBreakingChangeLabel) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: breakingChangeLabel
+              });
+            }


### PR DESCRIPTION
Adds a _new_ GitHub action that is triggered when a pull request is made, which can run parallel to other workflows.

1. Defines a series of labels that covers the previous set of conventional-commits noun list, but with a `Type: ` prefix, and by combining some lesser used nouns to a `Type: Misc` label.

2. These labels when updated downstream and sync'd with the actual labels, should provide first-class labels with their own colors and descriptions.

3. When a PR is made, the commits are analyzed, and based on the commit prefixes, the tags are updated. This task runs in parallel to the conventional-commits check, and is intentional because we have card ID checks, which the pr-labeler can run without.

4. This workflow also uses `permissions` to allow-list only repo contents and write access to PRs.


- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
