### PR TITLE
fix: update auto-repo-ansible permission to allow self-updates #8310

### DIFF
--- a/.github/workflows/auto-run-repo-ansible.yaml
+++ b/.github/workflows/auto-run-repo-ansible.yaml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: write # allow git commits & push
   pull-requests: write # allow comments on PR
+  actions: write # allow repo-ansible to update GH-Action workflow files
 
 env:
   # XXX alternative to missing ternary syntax


### PR DESCRIPTION
When running repo-ansible during a GitHub Actions run, changes made to the workflow files cannot be pushed unless permitted.

In the workflows, the following snippet control permissions:

```yaml
permissions:
  contents: write # allow git commits & push
  pull-requests: write # allow comments on PR
```

This works for repo contents (`contents: write`), but writing to workflows require `actions: write` permission. This commit adds it to the template.

However, all repos need to manually run repo-ansible and commit and push with more permissions, either as a user with write permissions or a with a PAT with workflows read/write permissions.


- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
