### PR TITLE
feat: add support for `repo.issue_url_format` #9668

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ your repository.
 | github<br>features<br>issues `boolean` |false| Enable issues tab.|
 | github<br>features<br>projects `boolean` |false| Enable projects tab.|
 | github_workflows<br>build<br>extra_docker_build_args `object` |{}| Key-value pairs to use as build args during the docker build step of build and release workflow|
+| github_workflows<br>release<br>issue_url_format `string` || Override the base URL for the issues mentioned with conventional-commits. Use {{id}} for the issue ID, as well other placeholders mentioned in https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#substitutions|
 | reviewdog<br>platforms `array` |[]| A broad way to categorize programming languages, libraries, and frameworks, and for which we have an external tool we can use to assure code quality during review.&nbsp; Accepted values:`php`,`twig`,||
 | devcontainer<br>custom_docker_compose_yaml `boolean` |false| When enabled the compose file located at .devcontainer/docker-compose.yaml will no longer get automatically updated. Allowing users to customize their docker-compose setup.|
 | devcontainer<br>postCreateCommand `string` |-| Additional (shell) commands to run when the containers is created. For a typical project you would specify commands that only need to run once when the project is setup. For example you might add a command in here to load database fixtures for your project.|

--- a/docs/partials/readme.configuration.md
+++ b/docs/partials/readme.configuration.md
@@ -30,6 +30,7 @@
 | github<br>features<br>issues `boolean` |false| Enable issues tab.|
 | github<br>features<br>projects `boolean` |false| Enable projects tab.|
 | github_workflows<br>build<br>extra_docker_build_args `object` |{}| Key-value pairs to use as build args during the docker build step of build and release workflow|
+| github_workflows<br>release<br>issue_url_format `string` || Override the base URL for the issues mentioned with conventional-commits. Use {{id}} for the issue ID, as well other placeholders mentioned in https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#substitutions|
 | reviewdog<br>platforms `array` |[]| A broad way to categorize programming languages, libraries, and frameworks, and for which we have an external tool we can use to assure code quality during review.&nbsp; Accepted values:`php`,`twig`,||
 | devcontainer<br>custom_docker_compose_yaml `boolean` |false| When enabled the compose file located at .devcontainer/docker-compose.yaml will no longer get automatically updated. Allowing users to customize their docker-compose setup.|
 | devcontainer<br>postCreateCommand `string` |-| Additional (shell) commands to run when the containers is created. For a typical project you would specify commands that only need to run once when the project is setup. For example you might add a command in here to load database fixtures for your project.|

--- a/repo.schema.yaml
+++ b/repo.schema.yaml
@@ -209,6 +209,18 @@ properties:
             default: {}
             description: >
               Key-value pairs to use as build args during the docker build step of build and release workflow
+      release:
+        type: object
+        additionalProperties: false
+        description: Configuration options for release process
+        properties:
+          issue_url_format:
+            type: string
+            default: ""
+            description: >
+              Override the base URL for the issues mentioned with conventional-commits.
+              Use {{id}} for the issue ID, as well other placeholders mentioned in
+              https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#substitutions
 
   reviewdog:
     type: object

--- a/repo.yaml
+++ b/repo.yaml
@@ -15,5 +15,5 @@ license: mit
 license_year: 2024
 name: repo-ansible
 type: other
-version: v0.17.0
+version: v0.18.0
 visibility: public

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -30,15 +30,14 @@ jobs:
         # (set provenance=false in docker/build-push-action@v4)
         driver-opts: network=host,image=moby/buildkit:v0.10.5
 
-    - id: semantic-release
-      uses: codfish/semantic-release-action@v3
-      with:
-        additional-packages: |
-          ['@semantic-release/changelog', '@semantic-release/git', '@semantic-release/exec']
-        repository-url: ${{ github.event.repository.clone_url }} # e.g. https://github.com/linkorb/linkorb.git
-        tag-format: 'v${version}'
+    - name: Semantic release
+      id: semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        npm install --no-save semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog @semantic-release/release-notes-generator
+        npx semantic-release --repository-url ${{ github.repositoryUrl }}
+        echo "release-version=$(cat .gitrelease)" >> "$GITHUB_OUTPUT"
 
     - id: meta
       uses: docker/metadata-action@v5

--- a/templates/.releaserc.cjs.j2
+++ b/templates/.releaserc.cjs.j2
@@ -18,8 +18,20 @@ module.exports = {
           { type: "style",    release: "patch" },
           { type: "test",     release: "patch" },
     ] } ],
-    "@semantic-release/github",
+{% if repo.github_workflows.release.issue_url_format %}
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "issueUrlFormat": "{{ repo.github_workflows.release.issue_url_format }}"
+        }
+      }
+    ],
+{% else %}
     "@semantic-release/release-notes-generator",
+{% endif %}
+    "@semantic-release/github",
     "@semantic-release/changelog",
 {% if package_json_version_bump %}
     [ "@semantic-release/npm", { npmPublish: false } ],
@@ -28,6 +40,6 @@ module.exports = {
         assets: [ "CHANGELOG.md" {% if package_json_version_bump %}, "package.json" {% endif %}],
         message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     } ],
-    [ "@semantic-release/exec", { publishCmd: "echo ${nextRelease.version} > .gitrelease" } ]
+    [ "@semantic-release/exec", { publishCmd: "echo -n ${nextRelease.version} > .gitrelease" } ]
   ]
 }


### PR DESCRIPTION
Adds support `repo.issue_url_format`, which updates the semantic-release config file. With this config, it is possible to override the base URL to which the issues are linked.

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
