### PR TITLE
feat: add support for configurable semantic-release #9706

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ your repository.
 | github<br>features<br>issues `boolean` |false| Enable issues tab.|
 | github<br>features<br>projects `boolean` |false| Enable projects tab.|
 | github_workflows<br>build<br>extra_docker_build_args `object` |{}| Key-value pairs to use as build args during the docker build step of build and release workflow|
+| github_workflows<br>release<br>commit_changed_files `array` |[]| A list of files in addition to CHANGELOG.md and package.json (for repo.type starting with `nodejs-`) to include in the commit with changes.|
+| github_workflows<br>release<br>issue_url_format `string` || Override the base URL for the issues mentioned with conventional-commits. Use {{id}} for the issue ID, as well other placeholders mentioned in https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#substitutions|
 | reviewdog<br>platforms `array` |[]| A broad way to categorize programming languages, libraries, and frameworks, and for which we have an external tool we can use to assure code quality during review.&nbsp; Accepted values:`php`,`twig`,||
 | devcontainer<br>custom_docker_compose_yaml `boolean` |false| When enabled the compose file located at .devcontainer/docker-compose.yaml will no longer get automatically updated. Allowing users to customize their docker-compose setup.|
 | devcontainer<br>postCreateCommand `string` |-| Additional (shell) commands to run when the containers is created. For a typical project you would specify commands that only need to run once when the project is setup. For example you might add a command in here to load database fixtures for your project.|

--- a/docs/partials/readme.configuration.md
+++ b/docs/partials/readme.configuration.md
@@ -30,6 +30,8 @@
 | github<br>features<br>issues `boolean` |false| Enable issues tab.|
 | github<br>features<br>projects `boolean` |false| Enable projects tab.|
 | github_workflows<br>build<br>extra_docker_build_args `object` |{}| Key-value pairs to use as build args during the docker build step of build and release workflow|
+| github_workflows<br>release<br>commit_changed_files `array` |[]| A list of files in addition to CHANGELOG.md and package.json (for repo.type starting with `nodejs-`) to include in the commit with changes.|
+| github_workflows<br>release<br>issue_url_format `string` || Override the base URL for the issues mentioned with conventional-commits. Use {{id}} for the issue ID, as well other placeholders mentioned in https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#substitutions|
 | reviewdog<br>platforms `array` |[]| A broad way to categorize programming languages, libraries, and frameworks, and for which we have an external tool we can use to assure code quality during review.&nbsp; Accepted values:`php`,`twig`,||
 | devcontainer<br>custom_docker_compose_yaml `boolean` |false| When enabled the compose file located at .devcontainer/docker-compose.yaml will no longer get automatically updated. Allowing users to customize their docker-compose setup.|
 | devcontainer<br>postCreateCommand `string` |-| Additional (shell) commands to run when the containers is created. For a typical project you would specify commands that only need to run once when the project is setup. For example you might add a command in here to load database fixtures for your project.|

--- a/repo.schema.yaml
+++ b/repo.schema.yaml
@@ -209,6 +209,26 @@ properties:
             default: {}
             description: >
               Key-value pairs to use as build args during the docker build step of build and release workflow
+      release:
+        type: object
+        additionalProperties: false
+        description: Configuration options for release process
+        properties:
+          commit_changed_files:
+            type: array
+            default: [ ]
+            items:
+              type: string
+            description: >
+              A list of files in addition to CHANGELOG.md and package.json (for repo.type starting with `nodejs-`) to
+              include in the commit with changes.
+          issue_url_format:
+            type: string
+            default: ""
+            description: >
+              Override the base URL for the issues mentioned with conventional-commits.
+              Use {{id}} for the issue ID, as well other placeholders mentioned in
+              https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#substitutions
 
   reviewdog:
     type: object

--- a/tasks/other-dev-generated-files.yaml
+++ b/tasks/other-dev-generated-files.yaml
@@ -5,7 +5,7 @@
       src: ./templates/.releaserc.cjs.j2
       dest: "{{ repo_path }}/.releaserc.cjs"
     vars:
-      package_json_version_bump: "{{ repo.type.startswith('nodejs-') }}"
+      package_json_version_bump: "{{ repo.type.startswith('nodejs-') or 'package.json' in repo.github_workflows.release.commit_changed_files }}"
 
   - name: find workflow extensions
     ansible.builtin.command: "./library/list_extension_workflows.py '{{ repo_path }}'"

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -30,15 +30,14 @@ jobs:
         # (set provenance=false in docker/build-push-action@v4)
         driver-opts: network=host,image=moby/buildkit:v0.10.5
 
-    - id: semantic-release
-      uses: codfish/semantic-release-action@v3
-      with:
-        additional-packages: |
-          ['@semantic-release/changelog', '@semantic-release/git', '@semantic-release/exec']
-        repository-url: ${{ github.event.repository.clone_url }} # e.g. https://github.com/linkorb/linkorb.git
-        tag-format: 'v${version}'
+    - name: Semantic release
+      id: semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        npm install --no-save semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog @semantic-release/release-notes-generator
+        npx semantic-release --repository-url ${{ github.server_url }}/${{ github.repository }}
+        echo "release-version=$(cat .gitrelease)" >> "$GITHUB_OUTPUT"
 
     - id: meta
       uses: docker/metadata-action@v5

--- a/templates/.releaserc.cjs.j2
+++ b/templates/.releaserc.cjs.j2
@@ -18,16 +18,38 @@ module.exports = {
           { type: "style",    release: "patch" },
           { type: "test",     release: "patch" },
     ] } ],
-    "@semantic-release/github",
+{% if repo.github_workflows.release.issue_url_format %}
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "issueUrlFormat": "{{ repo.github_workflows.release.issue_url_format }}"
+        }
+      }
+    ],
+{% else %}
     "@semantic-release/release-notes-generator",
+{% endif %}
+    [ "@semantic-release/github", {successCommentCondition: false, failCommentCondition: false} ],
     "@semantic-release/changelog",
 {% if package_json_version_bump %}
     [ "@semantic-release/npm", { npmPublish: false } ],
 {% endif %}
+    [ "@semantic-release/exec", { generateNotesCmd: "echo -n ${nextRelease.version} > .gitrelease" } ],
     [ "@semantic-release/git", {
-        assets: [ "CHANGELOG.md" {% if package_json_version_bump %}, "package.json" {% endif %}],
+        assets: [
+{% if package_json_version_bump %}
+          "package.json",
+{% endif %}
+{% if repo.github_workflows.release.commit_changed_files %}
+{% for filename in repo.github_workflows.release.commit_changed_files | default([]) %}
+          "{{ filename }}",
+{% endfor %}
+{% endif %}
+          "CHANGELOG.md"
+        ],
         message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    } ],
-    [ "@semantic-release/exec", { publishCmd: "echo ${nextRelease.version} > .gitrelease" } ]
+    } ]
   ]
 }


### PR DESCRIPTION
This is an encompassing change that improves how our semantic-release workflow, configuration, and playbooks work.

Currently, we use `codfish/semantic-release-action@v3` GitHub Action with a set of options specified in the workflow file. However, for downstream repositories that need fine-grained configuration, this can be a bit difficult to deal with.

## Config: Use `.releaserc.cjs` file

Currently, we build a `/.releaserc.cjs` file with quite meaningful defaults. However, in the GitHub action, it uses a custom set of options, so the `.releaserc.cjs` file does _not_ get used.

This PR fixes this by dropping the external GitHub action altogether, and using `npx semantic-release` directly within the action. It sets the repo URL, so repo forks can continue to work too.

Other than the repo URL, the rest of the configuration is now read from the `.releaserc.cjs` file.

## Release Notes: Custom Issue URL support

`semantic-release` process updates the `CHANGELOG.md` file and the commit body with links to the issues mentioned in the commit subject.

If the downstream repository does not use GitHub Issues, this can lead to non-existing or wrong links in the release notes and the commit message body.

`semantic-release` supports specifying a custom issue URL format with support for placeholder.

This PR exposes a _new_ option to override it:

`repo.github_workflows.release.issue_url_format`

When set, the release notes will be linked to this URL format, with support for placeholders such as `{{id}}` for the issue ID in the commit subject.

## Changed files

During the `semantic-release`, it can modify files that should be part of the release commit.

For example, the release notes are added to the `CHANGELOG.md` file. Additionally, it may need to include changes made to other files such as `package.json` or the `.gitrelease` file.

This PR exposes a _new_ option to specify an array of files that should be staged in the release commit. By default, the `CHANGELOG.md` file is included.

`repo.github_workflows.release.commit_changed_files`

If the files are not changed, nothing will happen.

If this list contains `package.json`, the `package.json` and `package-lock.json` files will be updated to contain the new release being created.

This adjusts the order of the semantic-release tasks to make sure the changes from the previous task are carried over and are considered in the next task.

## Example

Here is an example in the `repo.yaml` file containing the new options:

```yaml
github_workflows:
  release:
    issue_url_format: https://example.net/browse/PRJCT-{{id}}
    commit_changed_files:
      - "CHANGELOG.md"
      - "package.json"
      - "package-lock.json"
      - "composer.json"
      - "composer.lock"
      - ".gitrelease"
```

---

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

- [ ] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [ ] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)