### PR TITLE
fix(ci): drop cache arguments for docker build action #0000

### DIFF
--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -63,8 +63,6 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-to: type=gha
-        cache-from: type=gha
         # For additional docker build args set github_workflows.build.extra_docker_build_args in the repo.yaml file
         build-args: |
 {% for key, value in docker_build_args.items() %}


### PR DESCRIPTION
Older versions of the GitHub cache API are deprecated and cause random, deliberate, breakages starting with the 9th of April.

While we don't use those APIs directly, the docker action we depend upons seem to do so.

Disable the cache arguments as a stop gap and prevent future breakages in CI runs.


- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

