### PR TITLE
feat: run package installation during startup #0000

### DIFF
--- a/templates/.devcontainer/postCreate.sh.j2
+++ b/templates/.devcontainer/postCreate.sh.j2
@@ -7,18 +7,9 @@ git config --global --add safe.directory /app
 
 git config commit.template .devcontainer/git/linkorb_commit.template
 
-{% if repo.type in ['application', 'library', 'symfony-bundle'] or repo.type.startswith('php-') %}
-
 {% if repo.devcontainer.private_packagist %}
 composer config --global --auth http-basic.repo.packagist.com \
   "${GITHUB_USER:-$GITHUB_USER_ON_HOST}" "${PACKAGIST_TOKEN:-$PACKAGIST_TOKEN_ON_HOST}"
-{% endif %}
-
-COMPOSER_MEMORY_LIMIT=-1 composer install
-{% endif %}
-
-{% if repo.type.startswith('nodejs-') %}
-npm ci
 {% endif %}
 
 {{ repo.devcontainer.postCreateCommand|default('') }}

--- a/templates/.devcontainer/postStart.sh.j2
+++ b/templates/.devcontainer/postStart.sh.j2
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 # {{ repo_managed }}
 
+{% if repo.type in ['application', 'library', 'symfony-bundle'] or repo.type.startswith('php-') %}
+
+COMPOSER_MEMORY_LIMIT=-1 composer install
+{% endif %}
+
+{% if repo.type.startswith('nodejs-') %}
+npm ci
+{% endif %}
+
 {{ repo.devcontainer.postStartCommand|default('') }}


### PR DESCRIPTION
Running the package installation during startup of the container is more convenient than at creation time. Makes it less likely to encounter the issue of unmet dependencies when opening up the devcontainer across different branches.


<!-- Please indicate if your PR introduces a breaking change -->
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
