### PR TITLE
feat: harden workflows against Deputy Confusion attack vector #0000

### DIFF
--- a/.github/workflows/auto-merge-dependabot-prs.yaml
+++ b/.github/workflows/auto-merge-dependabot-prs.yaml
@@ -1,6 +1,9 @@
 # Managed by https://github.com/linkorb/repo-ansible. Manual changes will be overwritten.
 name: Auto-merge Dependabot PRs
-on: pull_request_target
+on:
+  # XXX merge PRs when opened, or reopened, but not when synchronized to protect against "Deputy Confusion Injection"
+  pull_request_target:
+    types: [opened, reopened]
 
 permissions:
   pull-requests: write # required for the action to read metadata

--- a/templates/.github/workflows/auto-merge-dependabot-prs.yaml.j2
+++ b/templates/.github/workflows/auto-merge-dependabot-prs.yaml.j2
@@ -1,6 +1,9 @@
 # [[ repo_managed ]]
 name: Auto-merge Dependabot PRs
-on: pull_request_target
+on:
+  # XXX merge PRs when opened, or reopened, but not when synchronized to protect against "Deputy Confusion Injection"
+  pull_request_target:
+    types: [opened, reopened]
 
 permissions:
   pull-requests: write # required for the action to read metadata


### PR DESCRIPTION
Based on the article
https://boostsecurity.io/blog/weaponizing-dependabot-pwn-request-at-its-finest

While the article states that usage of actions such as dependabot/fetch-metadata to some extent prevent against this types of attacks, we add an additional check to ensure that we don't followthrough with automated merging for synchronize related events.

<!-- Please indicate if your PR introduces a breaking change -->
- [x] Breaking change: fix or feature that would cause existing functionality to not work as expected

Automatic merging of Dependabot PRs won't happen anymore when a user instructs dependabot to rebase a PR, requiring a manual merge.

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

