### PR TITLE
fix: `devcontainer/Dockerfile` - use `ENV KEY=VAL` format #0000

### DIFF
--- a/templates/.devcontainer/Dockerfile.j2
+++ b/templates/.devcontainer/Dockerfile.j2
@@ -11,11 +11,11 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-ENV APACHE_RUN_USER    $USERNAME
-ENV APACHE_RUN_GROUP   $USERNAME
-ENV APACHE_LOCK_DIR    /var/lock/apache2
-ENV APACHE_LOG_DIR     /var/log/apache2
-ENV APACHE_PID_FILE    /var/run/apache2/apache2.pid
+ENV APACHE_RUN_USER=$USERNAME
+ENV APACHE_RUN_GROUP=$USERNAME
+ENV APACHE_LOCK_DIR=/var/lock/apache2
+ENV APACHE_LOG_DIR=/var/log/apache2
+ENV APACHE_PID_FILE=/var/run/apache2/apache2.pid
 
 # Create a non-root user with the specified UID and GID
 RUN groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
`Dockerfile` ref[^1] for `ENV` recommends the `ENV KEY=VALUE` format over the current `ENV KEY VALUE` format. Current Docker version complain about it during builds.

This is a quick PR that changes the `Dockerfile` template to use this format.

[^1]: https://docs.docker.com/reference/dockerfile/#env

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
