### PR TITLE
feat: add a `.dockerignore` file #0000

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+docker
+docs
+.dockerignore
+.editorconfig
+.gitignore
+CONTRIBUTING.md
+Dockerfile
+README.md


### PR DESCRIPTION
Add a `.dockerignore` file, so the Dockerfile's `COPY` calls do not copy files irrelevant for the Ansible run.

Saves about 1-2MB off the image size.

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)