### PR TITLE
feat: show diff in PR repo-ansible comment #0000

### DIFF
--- a/templates/.github/workflows/auto-run-repo-ansible.yaml.j2
+++ b/templates/.github/workflows/auto-run-repo-ansible.yaml.j2
@@ -49,6 +49,13 @@ jobs:
             echo EOF
           } >> "$GITHUB_ENV"
 
+          export DIFF=$(git diff)
+          {
+            echo 'REPO_ANSIBLE_DIFF<<EOF'
+            echo "$DIFF"
+            echo EOF
+          } >> "$GITHUB_ENV"
+
           if ! echo "$OUTPUT" | grep "changed=0"; then
             echo "REPOSITORY_CHANGED=1" >> "$GITHUB_ENV"
           fi
@@ -72,6 +79,7 @@ jobs:
         with:
           script: |
             const changes = process.env.REPO_ANSIBLE_OUTPUT
+            const diff = process.env.REPO_ANSIBLE_DIFF
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -81,5 +89,14 @@ jobs:
               \`\`\`shell
               ${changes}
               \`\`\`
+
+              <details>
+              <summary>See changes</summary>
+
+              \`\`\`diff
+              ${diff}
+              \`\`\`
+
+              </details>
             `
             })


### PR DESCRIPTION
`repo-ansible` maintains a GitHub Actions workflow that is triggered when a PR is made on the repo. It runs repo-ansible on the PR branch, and if running repo-ansible changes anything, it places a comment on the PR saying this:

```
Once PR is merged, repo-ansible will run on ... and the following
changes will apply
```

followed by the repo-ansible output.

The repo-ansible output shows how many files will be created, deleted, added, or modified. However, the exact changes are now shown in this comment.

This PR adds that feature. After a repo-ansible run that changes any repo-ansible-managed changes, the automatic commit now includes the exact diff of the change.

It is folded by default with a `See changes` section. When clicked, it opens syntax-highlighted `git diff` output. The folding keeps the comment clean, and the added diff makes the exact changes visible.

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
