### PR TITLE
GH-Actions: external actions pinning + updates #0000

### DIFF
--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -22,12 +22,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: docker/setup-qemu-action@v4
+      # v4 https://github.com/docker/setup-qemu-action/commit/ce360397dd3f832beb865e1373c09c0e9f86d70a
+    - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
       with:
         image: tonistiigi/binfmt:qemu-v10.2.1@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3
         platforms: linux/amd64
 
-    - uses: docker/setup-buildx-action@v4
+      # v4 https://github.com/docker/setup-buildx-action/commit/4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+    - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       with:
         driver-opts: network=host,image=moby/buildkit:v0.28.0@sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
         platforms: linux/amd64
@@ -42,7 +44,8 @@ jobs:
         echo "release-version=$(cat .gitrelease)" >> "$GITHUB_OUTPUT"
 
     - id: meta
-      uses: docker/metadata-action@v6
+      # v6 https://github.com/docker/metadata-action/commit/030e881283bb7a6894de51c315a6bfe6a94e05cf
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
       with:
         images: |
           ghcr.io/${{ github.repository }}
@@ -58,7 +61,8 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: docker/build-push-action@v6
+      # v7.1 https://github.com/docker/build-push-action/commit/bcafcacb16a39f128d818304e6c9c0c18556b85f
+    - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
       with:
         context: .
         provenance: false

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -54,8 +54,8 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
           type=raw,value=${{ steps.semantic-release.outputs.release-version }}
 
-      # v4 https://github.com/docker/login-action/commit/b45d80f862d83dbcd57f89517bcf500b2ab88fb2
-    - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      # v4.1 https://github.com/docker/login-action/commit/4907a6ddec9925e35a0a9e82d7399ccc52663121
+    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/templates/.github/workflows/auto-label-pull-request.yaml.j2
+++ b/templates/.github/workflows/auto-label-pull-request.yaml.j2
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label pull requests based on conventional commits
-        # v8 https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        # v9 https://github.com/actions/github-script/commit/3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/templates/.github/workflows/auto-merge-dependabot-prs.yaml.j2
+++ b/templates/.github/workflows/auto-merge-dependabot-prs.yaml.j2
@@ -15,8 +15,8 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - id: metadata
-        # v2 https://github.com/dependabot/fetch-metadata/commit/21025c705c08248db411dc16f3619e6b5f9ea21a
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
+        # v3.1 https://github.com/dependabot/fetch-metadata/commit/25dd0e34f4fe68f24cc83900b1fe3fe149efef98
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
 
       - if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --merge "$PR_URL"

--- a/templates/.github/workflows/auto-run-repo-ansible.yaml.j2
+++ b/templates/.github/workflows/auto-run-repo-ansible.yaml.j2
@@ -67,8 +67,8 @@ jobs:
 
       - if: ${{ env.IS_PULL_REQUEST == '1' && env.REPOSITORY_CHANGED == '1' }}
         name: bot comment about repo-ansible detected changes
-        # v8 https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        # v9 https://github.com/actions/github-script/commit/3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const changes = process.env.REPO_ANSIBLE_OUTPUT


### PR DESCRIPTION
## Proposed changes

 - Pins all version-referenced actions to their respective commit hashes
 - Updates outdated pinned actions to their latest versions, pinned to the commit hash.

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments

Does not conflict with GH-160.