### PR TITLE
Fix: Semantic-release template fixes #0000

### DIFF
--- a/templates/.releaserc.cjs.j2
+++ b/templates/.releaserc.cjs.j2
@@ -8,7 +8,6 @@
  */
 module.exports = {
   branches: ["{{ repo.github.default_branch }}"],
-  debug: "True",
   plugins: [
     [ "@semantic-release/commit-analyzer", { preset: "angular", releaseRules: [
           { type: "chore",    release: "patch" },

--- a/templates/.releaserc.cjs.j2
+++ b/templates/.releaserc.cjs.j2
@@ -38,15 +38,13 @@ module.exports = {
     [ "@semantic-release/exec", { generateNotesCmd: "echo -n ${nextRelease.version} > .gitrelease" } ],
     [ "@semantic-release/git", {
         assets: [
+{% set files = (repo.github_workflows.release.commit_changed_files | default([])) + ['CHANGELOG.md'] %}
 {% if package_json_version_bump %}
-          "package.json",
+{% set files = files + ['package.json'] %}
 {% endif %}
-{% if repo.github_workflows.release.commit_changed_files %}
-{% for filename in repo.github_workflows.release.commit_changed_files | default([]) %}
+{% for filename in files | unique | list | sort %}
           "{{ filename }}",
 {% endfor %}
-{% endif %}
-          "CHANGELOG.md"
         ],
         message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     } ]


### PR DESCRIPTION
Precursor to GH-163, this improves the `.releaserc.cjs` file template:

 - Drop `debug` key from exported options object. 
 - Streamline `package.json` and `CHANGELOG.md` inclusion in the commit containing the new release. The `CHANGELOG.md` file is always included. `package.json` file is included if the new release contains a `package.json` version bump.
 - The file list is made unique, meaning that even if the `repo.yaml`-`github_workflows.release.commit_changed_files` diirective includes `package.json` or `CHANGELOG.md`, it is not repeated in the `.releaserc.cjs` file. The list it neatly nat-sorted too. 

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
