### PR TITLE
security(ci): GH-actions/checkout don't persist GitHub creds #0000

### DIFF
--- a/templates/.github/workflows/10-review.yaml.j2
+++ b/templates/.github/workflows/10-review.yaml.j2
@@ -15,6 +15,8 @@ jobs:
     steps:
         # v6 https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       # interesting alternative: https://github.com/cocogitto/cocogitto
         # v1.3.0 https://github.com/webiny/action-conventional-commits/commit/8bc41ff4e7d423d56fa4905f6ff79209a78776c7
@@ -40,6 +42,8 @@ jobs:
     steps:
         # v6 https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: latest repo-ansible/reviewdog container
         run: docker pull ghcr.io/linkorb/repo-ansible/reviewdog:latest
       - name: run reviewdog checks

--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
+        persist-credentials: false
 
       # v4 https://github.com/docker/setup-qemu-action/commit/ce360397dd3f832beb865e1373c09c0e9f86d70a
     - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a

--- a/templates/.github/workflows/auto-run-repo-ansible.yaml.j2
+++ b/templates/.github/workflows/auto-run-repo-ansible.yaml.j2
@@ -31,12 +31,15 @@ jobs:
       - if: ${{ env.IS_PULL_REQUEST == '0' }}
         # v6 https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - if: ${{ env.IS_PULL_REQUEST == '1' }}
         # v6 https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          persist-credentials: false
 
       - name: repo-ansible
         run: |


### PR DESCRIPTION
Making use of the new feature in [actions/checkout@v6](https://github.com/actions/checkout#whats-new-1), using `persist-credentials: false` so the GitHub credentials are not stored in config files.

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
