### PR TITLE
feat(dockerignore): update default dockerignore template #0000

### DIFF
--- a/templates/.dockerignore.j2
+++ b/templates/.dockerignore.j2
@@ -1,5 +1,13 @@
 # {{ repo_managed }}
 
-node_modules/
-vendor/
-var/
+/.cursorrules/
+/.git/
+/.github/
+/docker/
+/docs/
+/node_modules/
+/var/
+/vendor/
+/.dockerignore
+/.editorconfig
+/.gitignore


### PR DESCRIPTION
Updates the `.dockerignore` template to ignore a more comprehensive set of files from the container build context. 

Notably, the `.dockerignore` file does _not_ ignore `.devcontainer` folder because this folder contains `postCreate.sh` and `postStart.sh` files that may be used later from within the container context. 

The `node_modules` and `vendor` folders were already excluded. This merely sorts them. 

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
