### PR TITLE
chore: adjust gh-actions semantic-release step order #0000

### DIFF
--- a/templates/.github/workflows/30-release-and-build.yaml.j2
+++ b/templates/.github/workflows/30-release-and-build.yaml.j2
@@ -22,6 +22,15 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Semantic release
+      id: semantic-release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        npm install --no-save semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog @semantic-release/release-notes-generator conventional-changelog-conventionalcommits
+        npx semantic-release --repository-url ${{ github.server_url }}/${{ github.repository }}
+        echo "release-version=$(cat .gitrelease)" >> "$GITHUB_OUTPUT"
+
       # v4 https://github.com/docker/setup-qemu-action/commit/ce360397dd3f832beb865e1373c09c0e9f86d70a
     - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
       with:
@@ -33,15 +42,6 @@ jobs:
       with:
         driver-opts: network=host,image=moby/buildkit:v0.28.0@sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
         platforms: linux/amd64
-
-    - name: Semantic release
-      id: semantic-release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        npm install --no-save semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog @semantic-release/release-notes-generator conventional-changelog-conventionalcommits
-        npx semantic-release --repository-url ${{ github.server_url }}/${{ github.repository }}
-        echo "release-version=$(cat .gitrelease)" >> "$GITHUB_OUTPUT"
 
     - id: meta
       # v6 https://github.com/docker/metadata-action/commit/030e881283bb7a6894de51c315a6bfe6a94e05cf


### PR DESCRIPTION
Moves the `semantic-release` step in the build GH-actions workflow to be executed right after the checkout. It does not depend on the Docker-releated actions such as login and qemu setup, so there is no reason for the `semantic-release` to be not executed earlier.

This not only reduces clutter, but also enables us to eventually execute multiple steps in parallel[^1].

[^1]: https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
