### PR TITLE
feat: managed .github/copilot-instructions.md with opt-out and repo-specific extension #0000

### DIFF
--- a/repo.schema.yaml
+++ b/repo.schema.yaml
@@ -150,6 +150,16 @@ properties:
         description: GitHub features
         additionalProperties: false
         properties:
+          copilot_instructions:
+            description: >
+              Generate a managed `.github/copilot-instructions.md` with organization-wide guidance used by
+              GitHub Copilot code review. Extend it with repo-specific guidance in
+              `docs/partials/copilot-instructions.md`, appended on the next repo-ansible run.<br>
+              *Set to `false` to opt out: the managed file is removed; hand-written files without the
+              managed header are never touched.*
+            type: boolean
+            default: true
+
           dependabot_auto_merge:
             description: >
               Generate workflow that automatically merges Dependabot PRs for patch and minor version releases.<br>

--- a/tasks/generate-files.yaml
+++ b/tasks/generate-files.yaml
@@ -63,6 +63,28 @@
     dest: "{{ repo_path }}/CONTRIBUTING.md"
   when: "'CONTRIBUTING.md' not in repo.omit_files"
 
+- name: Generate copilot-instructions file
+  ansible.builtin.template:
+    src: ./templates/.github/copilot-instructions.md.j2
+    dest: "{{ repo_path }}/.github/copilot-instructions.md"
+  when: repo.github.features.copilot_instructions
+
+- name: Check for existing copilot-instructions file (opt-out)
+  ansible.builtin.stat:
+    path: "{{ repo_path }}/.github/copilot-instructions.md"
+  register: copilot_instructions_stat
+  when: not repo.github.features.copilot_instructions
+
+# only remove a file repo-ansible generated (marker check); hand-written files are kept
+- name: Remove managed copilot-instructions file (opt-out)
+  when:
+    - not repo.github.features.copilot_instructions
+    - copilot_instructions_stat.stat.exists
+    - "'<!-- Managed by https://github.com/linkorb/repo-ansible' in lookup('file', repo_path + '/.github/copilot-instructions.md')"
+  ansible.builtin.file:
+    path: "{{ repo_path }}/.github/copilot-instructions.md"
+    state: absent
+
 - name: generate README.md file
   ansible.builtin.template:
     src: ./templates/README.md.j2

--- a/tasks/migrations/migration-v0.25.0.yaml
+++ b/tasks/migrations/migration-v0.25.0.yaml
@@ -1,0 +1,30 @@
+# Preserve a pre-existing hand-written .github/copilot-instructions.md as the
+# repo-specific partial before the managed file is first generated.
+# Runs regardless of the copilot_instructions flag (repo.yaml defaults are not
+# yet merged at migration time); for opted-out repos this leaves a harmless
+# preserved copy while the original file stays untouched.
+- name: stat existing copilot-instructions file
+  ansible.builtin.stat:
+    path: "{{ repo_path }}/.github/copilot-instructions.md"
+  register: migration_copilot_stat
+
+- when: migration_copilot_stat.stat.exists
+  block:
+    - name: read existing copilot-instructions file
+      ansible.builtin.slurp:
+        src: "{{ repo_path }}/.github/copilot-instructions.md"
+      register: migration_copilot_source
+
+    # marker literal is hardcoded: repo_managed is set after migrations run
+    - when: "'<!-- Managed by https://github.com/linkorb/repo-ansible' not in (migration_copilot_source.content | b64decode)"
+      block:
+        - name: ensure docs/partials directory exists
+          ansible.builtin.file:
+            path: "{{ repo_path }}/docs/partials"
+            state: directory
+
+        - name: preserve hand-written copilot instructions as repo-specific partial
+          ansible.builtin.copy:
+            content: "{{ migration_copilot_source.content | b64decode }}"
+            dest: "{{ repo_path }}/docs/partials/copilot-instructions.md"
+            force: false

--- a/templates/.github/copilot-instructions.md.j2
+++ b/templates/.github/copilot-instructions.md.j2
@@ -1,0 +1,29 @@
+<!-- {{ repo_managed }} -->
+<!-- Repo-specific guidance: docs/partials/copilot-instructions.md (appended below).
+     Opt out via github.features.copilot_instructions in repo.yaml. -->
+# Copilot instructions for {{ repo.name }}
+
+{{ repo.description }}
+
+## Engineering controls
+
+- Files containing the header `Managed by https://github.com/linkorb/repo-ansible` are
+  generated. Flag any change that hand-edits them; the edit will be overwritten on the
+  next repo-ansible run. The correct change is in `repo.yaml` or `docs/partials/` instead.
+- GitHub Actions in workflows must be pinned to a full commit SHA with a version comment
+  (`# vN https://github.com/...`), never a mutable tag like `@v4`. Tags can be repointed
+  to malicious commits when an action's repository is compromised; a pinned SHA is immutable
+  and blocks that supply-chain attack. Flag any `uses:` that is not SHA-pinned.
+- Flag new or version-changed dependencies in manifest files (composer.json, package.json,
+  etc.) with copyleft licenses: AGPL always; GPL/LGPL for discussion.
+- Flag new files or code blocks that appear to be third-party source (foreign copyright
+  headers, embedded license notices, wholesale-copied implementations) so licensing can
+  be verified. These bypass dependency manifests and are invisible to dependency scanners.
+- When reviewing, flag new code comments that merely restate the adjacent code.
+{% set copilot_partial_path = repo_path + '/docs/partials/copilot-instructions.md' %}
+{% if copilot_partial_path in doc_files_array | map(attribute='path') %}
+
+## Repository-specific guidance
+
+{{ lookup('file', copilot_partial_path) }}
+{% endif %}


### PR DESCRIPTION
GitHub Copilot code review is somewhat active across the org, but has no centralized guidance.

While a small number of repos (~3) have hand-written `.github/copilot-instructions.md`, on all others Copilot reviews blind. This PR makes repo-ansible distribute a managed instructions file fleet-wide, with per-repo opt-out and extension, so review guidance becomes versioned and consistent.

> [!NOTE]
> **Why a repo-managed file instead of [GitHub's org-level custom instructions](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-organization-instructions)?** Org custom instructions would apply fleet-wide with no file distribution at all and are visible/editable only to org owners, have no version history, and change without diffs or review. This approach is more transparent and collaborative, while supporting opt-out per repo. The mechanisms also do not conflict: GitHub combines instruction layers (personal, then repository, then organization), so org-level instructions can still be added later for anything truly universal.

## Summary

- New managed file `.github/copilot-instructions.md`, generated for every repo; opt out via `github.features.copilot_instructions: false` in `repo.yaml` (schema default `true`).
- Repo-specific guidance lives in `docs/partials/copilot-instructions.md` and is appended to the generated file (same lifecycle as README partials; the auto-run workflow already triggers on partial changes).
- Opt-out removes a previously generated file only when it carries the repo-ansible managed header. Hand-written files are never touched. This marker-guarded removal is a new pattern for this codebase, chosen because this file (unlike other managed files) plausibly pre-exists by hand.
- Migration (`migration-v0.25.0.yaml`, pinned to the current release so any next tag works) preserves pre-existing hand-written files into `docs/partials/` before first generation. A fleet scan found exactly two affected repos (`orfeus-4-ionic`, `orfeus-bridge`); the migration makes their rollout coordination-free.
- Seed content: five engineering controls (the template carries the actual text). Deliberately minimal; guidance grows in later PRs. Editorial review of the wording is welcome.

## Testing

- [x] `ansible-playbook --syntax-check` passes in the container built from this branch.
- [x] Fixture repo, full apply: file generated with managed marker line 1; partial spliced under "Repository-specific guidance"; re-run is idempotent (`changed=0` on no-op).
- [x] Opt-out: flag `false` removes the managed file; restoring the flag regenerates it.
- [x] Protection: hand-written file without the marker survives opt-out runs, including a file that mentions the repo-ansible URL in prose.
- [x] Migration: fixture at `version: v0.25.0` with a hand-written file; content preserved to `docs/partials/copilot-instructions.md`, spliced into the regenerated file, stamped to the tool version; second run skips the migration (`changed=0`).
- [x] Real-repo onboarding test: ran this branch against a clone of a repo with a hand-written instructions file; content preserved verbatim to the partial and spliced into the generated file.
- [x] Schema: string value fails (`'yes' is not of type 'boolean'`); typo'd key fails (`Additional properties are not allowed`); config docs row renders via `schema_to_docs_partial.py`.

https://claude.ai/code/session_0113Qh5NkNZh8scU2ia84pTC
